### PR TITLE
General Bug Fixes For The 'grad' Command

### DIFF
--- a/GradiGen/Application/Commands/GradientCommand.cs
+++ b/GradiGen/Application/Commands/GradientCommand.cs
@@ -53,7 +53,7 @@ namespace GradiGen.App.Commands
             else
                 steps = AnsiConsole.Prompt<int>(new TextPrompt<int>("[grey]How dense do you want your gradient to be?[/]")
                     .Validate(x => x is > 1 and < int.MaxValue) // Fixes custom density to have any desired inputs
-                    .ValidationErrorMessage("[red]Please define a value between 2 and 100."));
+                    .ValidationErrorMessage($"[red]Please define a value between 2 and {int.MaxValue}."));
 
             var gradient = result.Item1.GenerateGradient(result.Item2, steps - 1); // Fixes the output from producing an unwanted extra color
 

--- a/GradiGen/Application/Commands/GradientCommand.cs
+++ b/GradiGen/Application/Commands/GradientCommand.cs
@@ -45,17 +45,17 @@ namespace GradiGen.App.Commands
                     .PageSize(10)
                     .MoreChoicesText("[grey](Move up and down to reveal more options)[/]");
 
-                for (int i = 1; i < input.Length; i++)
+                for (int i = 1; i < input.Length + 1; i++) // Fixes density allowing each char to be assigned a color
                     stepsPrompt.AddChoice(i);
 
                 steps = AnsiConsole.Prompt<int>(stepsPrompt);
             }
             else
                 steps = AnsiConsole.Prompt<int>(new TextPrompt<int>("[grey]How dense do you want your gradient to be?[/]")
-                    .Validate(x => x is > 1 and < 100)
+                    .Validate(x => x is > 1 and < int.MaxValue) // Fixes custom density to have any desired inputs
                     .ValidationErrorMessage("[red]Please define a value between 2 and 100."));
 
-            var gradient = result.Item1.GenerateGradient(result.Item2, steps);
+            var gradient = result.Item1.GenerateGradient(result.Item2, steps - 1); // Fixes the output from producing an unwanted extra color
 
             var formatValues = Enum.GetValues<FormatType>();
 


### PR DESCRIPTION
### Formatting Text - Density Issues

When typing a formatting text, for example the word `Hello`, there would not be the correct number of density options.
![before01](https://user-images.githubusercontent.com/33048298/183013386-f5fa0b20-2865-488f-8bbe-0a5ce894c754.PNG)

This has been fixed to the follow:
![01](https://user-images.githubusercontent.com/33048298/183013425-81fb41a6-3373-49bd-93ff-c7e09ab24054.PNG)
![02](https://user-images.githubusercontent.com/33048298/183013687-bc32039b-1b52-4ef9-99c2-f59ca6761b66.PNG)

### Empty Formatting Text - Density Issues

When choosing to skip a formatting text, the application will switch to a user defined input for density; aka - the amount of colors to generate. Previously, this feature would break / crash the application if the number was over the value of `99`. This has now been fixed.
![03](https://user-images.githubusercontent.com/33048298/183014662-ac659471-d722-4344-a476-9d33e90e8d71.PNG)

### Empty Formatting Text - Output Producing an Unwanted Extra Color

This issue when using the empty formatting text would would generate one number higher then defined by the user. I have gone and fixed this issue.
![04](https://user-images.githubusercontent.com/33048298/183014488-15d3cd40-477b-4e93-9770-bb8b527b95d8.PNG)